### PR TITLE
Possibility to set default file name to write to using nwsaveas

### DIFF
--- a/Source/WebKit/chromium/src/ChromeClientImpl.cpp
+++ b/Source/WebKit/chromium/src/ChromeClientImpl.cpp
@@ -651,8 +651,11 @@ void ChromeClientImpl::runOpenPanel(Frame* frame, PassRefPtr<FileChooser> fileCh
     params.directory = fileChooser->settings().directoryChooser || fileChooser->settings().allowsDirectoryUpload;
     params.acceptTypes = fileChooser->settings().acceptTypes();
     params.selectedFiles = fileChooser->settings().selectedFiles;
-    if (params.selectedFiles.size() > 0)
+    if (params.selectedFiles.size() > 0) {
         params.initialValue = params.selectedFiles[0];
+    } else {
+        params.initialValue = fileChooser->settings().initialValue;
+    }
     params.extractDirectory = fileChooser->settings().allowsDirectoryUpload;
     params.saveAs = fileChooser->settings().saveAs;
 #if ENABLE(MEDIA_CAPTURE)

--- a/Source/core/html/FileInputType.cpp
+++ b/Source/core/html/FileInputType.cpp
@@ -156,6 +156,7 @@ void FileInputType::handleDOMActivateEvent(Event* event)
         settings.capture = input->capture();
 #endif
         settings.initialPath = input->nwworkingdir();
+        settings.initialValue = input->nwsaveas();
         chrome->runOpenPanel(input->document()->frame(), newFileChooser(settings));
     }
     event->setDefaultHandled();

--- a/Source/core/html/HTMLInputElement.cpp
+++ b/Source/core/html/HTMLInputElement.cpp
@@ -1776,6 +1776,16 @@ void HTMLInputElement::setNwworkingdir(const String& value)
     setAttribute(nwworkingdirAttr, value);
 }
 
+String HTMLInputElement::nwsaveas() const
+{
+    return fastGetAttribute(nwsaveasAttr);
+}
+
+void HTMLInputElement::setNwsaveas(const String& value)
+{
+    setAttribute(nwsaveasAttr, value);
+}
+
 bool HTMLInputElement::isInRequiredRadioButtonGroup()
 {
     ASSERT(isRadioButton());

--- a/Source/core/html/HTMLInputElement.h
+++ b/Source/core/html/HTMLInputElement.h
@@ -268,6 +268,9 @@ public:
     String nwworkingdir() const;
     void setNwworkingdir(const String& value);
 
+    String nwsaveas() const;
+    void setNwsaveas(const String& value);
+
     static const int maximumLength;
 
     unsigned height() const;

--- a/Source/core/html/HTMLInputElement.idl
+++ b/Source/core/html/HTMLInputElement.idl
@@ -98,5 +98,7 @@
 
     // See http://www.w3.org/TR/html-media-capture/
     [Conditional=MEDIA_CAPTURE] attribute DOMString capture;
+
     attribute DOMString nwworkingdir;
+    attribute DOMString nwsaveas;
 };

--- a/Source/core/platform/FileChooser.h
+++ b/Source/core/platform/FileChooser.h
@@ -65,6 +65,7 @@ struct FileChooserSettings {
     Vector<String> acceptTypes() const;
 
     String initialPath;
+    String initialValue;
 };
 
 class FileChooserClient {


### PR DESCRIPTION
Feature request from rogerwang/node-webkit#626 and some more. Generally I need that myself.

Now you can propose default filename for user. Examples:
1. The way it was before continues working as well
   `<input style="display:none" id="save-file-dialog" type="file" nwsaveas>`
   User gets saveAs dialog without any proposed name
2. Proposing name:
   `<input style="display:none" id="save-file-dialog" type="file" nwsaveas="test.txt">`
   Note `nwsaveas` attribute now has file name.
3. Proposing full file path and it's name — this is actually unplanned bonus… :smile:
   `<input style="display:none" id="save-file-dialog" type="file" nwsaveas="c:\dev\nw\test.txt">`

Note you still can use nwworkingdir and add new nwsaveas filename proposing (without path) — there is no any compability break.

Compiled and tested on windows 8. Hope you merge it.
