### PR TITLE
BitmapImage::imageForDefaultFrame() doesn't check, whether frame can be decoded

### DIFF
--- a/Source/platform/graphics/BitmapImage.cpp
+++ b/Source/platform/graphics/BitmapImage.cpp
@@ -374,7 +374,7 @@ PassRefPtr<Image> BitmapImage::imageForDefaultFrame()
 {
 	if (isBitmapImage() && maybeAnimated()) {
 		RefPtr<NativeImageSkia> fr = frameAtIndex(0);
-		if (fr) return BitmapImage::create();
+		if (fr) return BitmapImage::create(fr);
 	}
 
     return Image::imageForDefaultFrame();

--- a/Source/platform/graphics/BitmapImage.cpp
+++ b/Source/platform/graphics/BitmapImage.cpp
@@ -335,8 +335,12 @@ bool BitmapImage::ensureFrameIsCached(size_t index)
     if (index >= frameCount())
         return false;
 
-    if (index >= m_frames.size() || !m_frames[index].m_frame)
-        cacheFrame(index);
+	if (index >= m_frames.size() || !m_frames[index].m_frame) {
+		cacheFrame(index);
+		if (index >= m_frames.size() || !m_frames[index].m_frame) {
+			return false;
+		}
+	}
     return true;
 }
 
@@ -368,8 +372,10 @@ PassRefPtr<NativeImageSkia> BitmapImage::nativeImageForCurrentFrame()
 
 PassRefPtr<Image> BitmapImage::imageForDefaultFrame()
 {
-    if (isBitmapImage() && maybeAnimated())
-        return BitmapImage::create(frameAtIndex(0));
+	if (isBitmapImage() && maybeAnimated()) {
+		RefPtr<NativeImageSkia> fr = frameAtIndex(0);
+		if (fr) return BitmapImage::create();
+	}
 
     return Image::imageForDefaultFrame();
 }


### PR DESCRIPTION
Hotfix to solve crash in webkit 

Reproduction:
Note: Source image can be later unavailable-
In console:

var oc = document.createElement('canvas');

var octx = this.oc.getContext('2d');

var elmImg = document.createElement("img");

elmImg.addEventListener("load",function(){
   octx.drawImage(elmImg, 0, 0);
});

elmImg.src = "http://www.minorit.com/favicon.ico";
document.body.appendChild(elmImg);
=== crashed here ===
