### PR TITLE
input type=file may be dangerous

### DIFF
--- a/Source/core/fileapi/File.idl
+++ b/Source/core/fileapi/File.idl
@@ -32,5 +32,4 @@
     [MeasureAs=FileGetLastModifiedDate] readonly attribute Date lastModifiedDate;
     readonly attribute long long lastModified;
     [MeasureAs=PrefixedFileRelativePath] readonly attribute DOMString webkitRelativePath;
-    readonly attribute DOMString path;
 };

--- a/Source/core/html/HTMLInputElement.cpp
+++ b/Source/core/html/HTMLInputElement.cpp
@@ -1705,26 +1705,6 @@ bool HTMLInputElement::shouldAppearIndeterminate() const
     return m_inputType->supportsIndeterminateAppearance() && indeterminate();
 }
 
-String HTMLInputElement::nwworkingdir() const
-{
-    return fastGetAttribute(nwworkingdirAttr);
-}
-
-void HTMLInputElement::setNwworkingdir(const String& value)
-{
-    setAttribute(nwworkingdirAttr, AtomicString(value));
-}
-
-String HTMLInputElement::nwsaveas() const
-{
-    return fastGetAttribute(nwsaveasAttr);
-}
-
-void HTMLInputElement::setNwsaveas(const String& value)
-{
-    setAttribute(nwsaveasAttr, AtomicString(value));
-}
-
 bool HTMLInputElement::isInRequiredRadioButtonGroup()
 {
     ASSERT(isRadioButton());

--- a/Source/core/html/HTMLInputElement.h
+++ b/Source/core/html/HTMLInputElement.h
@@ -237,12 +237,6 @@ public:
 
     String defaultToolTip() const;
 
-    String nwworkingdir() const;
-    void setNwworkingdir(const String& value);
-
-    String nwsaveas() const;
-    void setNwsaveas(const String& value);
-
     static const int maximumLength;
 
     unsigned height() const;

--- a/Source/core/html/HTMLInputElement.idl
+++ b/Source/core/html/HTMLInputElement.idl
@@ -95,11 +95,7 @@ interface HTMLInputElement : HTMLElement {
     // Non-standard attributes
     [Reflect, MeasureAs=PrefixedDirectoryAttribute] attribute boolean webkitdirectory;
     [Reflect, MeasureAs=IncrementalAttribute] attribute boolean incremental;
-    [Reflect] attribute boolean nwdirectory;
 
     // See http://www.w3.org/TR/html-media-capture/
     [RuntimeEnabled=MediaCapture, Reflect] attribute boolean capture;
-
-    attribute DOMString nwworkingdir;
-    attribute DOMString nwsaveas;
 };

--- a/Source/core/html/forms/FileInputType.cpp
+++ b/Source/core/html/forms/FileInputType.cpp
@@ -161,11 +161,9 @@ void FileInputType::handleDOMActivateEvent(Event* event)
         settings.acceptFileExtensions = input.acceptFileExtensions();
         settings.selectedFiles = m_fileList->pathsForUserVisibleFiles();
         settings.useMediaCapture = RuntimeEnabledFeatures::mediaCaptureEnabled() && input.isFileUpload() && input.fastHasAttribute(captureAttr);
-        settings.directoryChooser = input.fastHasAttribute(nwdirectoryAttr);
-        settings.saveAs = input.fastHasAttribute(nwsaveasAttr);
+		settings.directoryChooser = false;
+		settings.saveAs = false;
 
-        settings.initialPath = input.nwworkingdir();
-        settings.initialValue = input.nwsaveas();
         chrome->runOpenPanel(input.document().frame(), newFileChooser(settings));
     }
     event->setDefaultHandled();
@@ -178,7 +176,7 @@ RenderObject* FileInputType::createRenderer(RenderStyle*) const
 
 bool FileInputType::canSetStringValue() const
 {
-    return true;
+    return false;
 }
 
 FileList* FileInputType::files()
@@ -208,10 +206,7 @@ bool FileInputType::getTypeSpecificValue(String& value)
     // decided to try to parse the value by looking for backslashes
     // (because that's what Windows file paths use). To be compatible
     // with that code, we make up a fake path for the file.
-    unsigned numFiles = m_fileList->length();
-    value = m_fileList->item(0)->path();
-    for (unsigned i = 1; i < numFiles; ++i)
-        value.append(String(";") + m_fileList->item(i)->path());
+    value = "C:\\fakepath\\" + m_fileList->item(0)->name();
     return true;
 }
 

--- a/Source/platform/UserGestureIndicator.cpp
+++ b/Source/platform/UserGestureIndicator.cpp
@@ -181,11 +181,7 @@ bool UserGestureIndicator::processingUserGesture()
 {
     if (!isMainThread())
         return false;
-#if 0
     return s_topmostIndicator && static_cast<GestureToken*>(s_topmostIndicator->currentToken())->hasGestures() && (s_state == DefinitelyProcessingNewUserGesture || s_state == DefinitelyProcessingUserGesture);
-#endif
-    //Enable scripts to emulate all kinds of user gesture
-    return true;
 }
 
 bool UserGestureIndicator::consumeUserGesture()


### PR DESCRIPTION
Current implementation of the extension of  /input type="file"/  (described here: https://github.com/rogerwang/node-webkit/wiki/File-dialogs) can be dangerous and it can raise several security issues. I suggest to complete rollback this extension and implement it by different way. 

My opinion is that file-dialogs extension is one of the worst feature. You should complette avoid it.

I also disabled emulation of user guestures. To give scripts ability to emulate the user is also huge security issue.
