### PR TITLE
Fix X-Frame-Options when top frame is nodejs

### DIFF
--- a/Source/core/loader/FrameLoader.cpp
+++ b/Source/core/loader/FrameLoader.cpp
@@ -1397,9 +1397,10 @@ bool FrameLoader::shouldInterruptLoadForXFrameOptions(const String& content, con
     UseCounter::count(m_frame->domWindow()->document(), UseCounter::XFrameOptions);
 
     Frame* topFrame = m_frame->tree().top();
-    if (m_frame == topFrame)
+	Frame* parentFrame = m_frame->tree().parent();
+	if (m_frame == topFrame)
         return false;
-    if (topFrame->isNodeJS())
+    if (parentFrame->isNodeJS())
         return false;
 
     XFrameOptionsDisposition disposition = parseXFrameOptionsHeader(content);


### PR DESCRIPTION
Security Issue. Apparently X-Frame-Options is ignored, when top frame is nodejs-frame. 

document.write('&lt;iframe src="http://software.sbeta.cz" width="500" height="500"&gt;&lt;/iframe&gt;'); 

The page contains iframe, which leads to page which has disabled showin up in the iframe. But it appear here. This is not WAI.

Opening the page directly WAI.

Following fix just makes test, whether parent frame is nodeJs frame. If this test pass, then X-Frame-Options is not checked. Previous version checked the top frame, not the parent frame. 

There is still possibility, that this issue can be solved by different way, but it is to hard for me with my grade of the knowledge about the blink and nw. Probably, the function top() should return faketop instead of real top frame. Please look into it.
