### PR TITLE
ScriptState used by EventListener::handleEvent() is wrong

### DIFF
--- a/LayoutTests/fast/events/before-unload-return-bad-value-expected.txt
+++ b/LayoutTests/fast/events/before-unload-return-bad-value-expected.txt
@@ -1,10 +1,9 @@
+CONSOLE ERROR: line 16: Uncaught Exception in toString()
 Tests that an exception is thrown when the value returned in the beforeunload callback cannot be converted to a String
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS Exception was thrown
-PASS testMessage is "Uncaught Exception in toString()"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/events/before-unload-return-bad-value.html
+++ b/LayoutTests/fast/events/before-unload-return-bad-value.html
@@ -18,6 +18,7 @@ function test(frame) {
 var testMessage;
 window.onerror = function(msg) {
     testMessage = msg;
+    // FIXME: This test fails. See crbug.com/446147.
     testPassed("Exception was thrown");
     shouldBeEqualToString("testMessage", "Uncaught Exception in toString()");
     setTimeout(finishJSTest, 0);

--- a/LayoutTests/fast/events/event-should-be-dispatched-for-correct-frame-expected.txt
+++ b/LayoutTests/fast/events/event-should-be-dispatched-for-correct-frame-expected.txt
@@ -1,0 +1,5 @@
+PASS Event is correctly dispatched
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/event-should-be-dispatched-for-correct-frame.html
+++ b/LayoutTests/fast/events/event-should-be-dispatched-for-correct-frame.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="frames"></div>
+<script type="text/javascript">
+function handleEvent(event) {
+  testPassed("Event is correctly dispatched");
+}
+
+var frame1 = document.createElement("iframe");
+document.getElementById("frames").appendChild(frame1);
+frame1.contentDocument.body.addEventListener("click", handleEvent);
+
+var frame2 = document.createElement("iframe");
+document.getElementById("frames").appendChild(frame2);
+frame2.contentDocument.body.addEventListener("click", handleEvent);
+
+document.getElementById("frames").removeChild(frame1);
+
+frame2.contentDocument.body.click();
+</script>
+</body>
+</html>

--- a/Source/bindings/core/v8/ScriptState.h
+++ b/Source/bindings/core/v8/ScriptState.h
@@ -33,7 +33,7 @@ public:
             : m_handleScope(scriptState->isolate())
             , m_context(scriptState->context())
         {
-            ASSERT(!m_context.IsEmpty());
+            ASSERT(!scriptState->contextIsEmpty());
             m_context->Enter();
         }
 

--- a/Source/bindings/core/v8/V8AbstractEventListener.cpp
+++ b/Source/bindings/core/v8/V8AbstractEventListener.cpp
@@ -43,20 +43,10 @@
 
 namespace blink {
 
-V8AbstractEventListener::V8AbstractEventListener(bool isAttribute, ScriptState* scriptState)
+V8AbstractEventListener::V8AbstractEventListener(bool isAttribute, DOMWrapperWorld& world, v8::Isolate* isolate)
     : EventListener(JSEventListenerType)
     , m_isAttribute(isAttribute)
-    , m_scriptState(scriptState)
-    , m_isolate(scriptState->isolate())
-{
-    if (isMainThread())
-        InspectorCounters::incrementCounter(InspectorCounters::JSEventListenerCounter);
-}
-
-V8AbstractEventListener::V8AbstractEventListener(bool isAttribute, v8::Isolate* isolate)
-    : EventListener(JSEventListenerType)
-    , m_isAttribute(isAttribute)
-    , m_scriptState(nullptr)
+    , m_world(world)
     , m_isolate(isolate)
 {
     if (isMainThread())
@@ -73,29 +63,41 @@ V8AbstractEventListener::~V8AbstractEventListener()
         InspectorCounters::decrementCounter(InspectorCounters::JSEventListenerCounter);
 }
 
-void V8AbstractEventListener::handleEvent(ExecutionContext*, Event* event)
+void V8AbstractEventListener::handleEvent(ExecutionContext* executionContext, Event* event)
 {
-    if (scriptState()->contextIsEmpty())
-        return;
-    if (!scriptState()->executionContext())
+    if (!executionContext)
         return;
     // Don't reenter V8 if execution was terminated in this instance of V8.
-    if (scriptState()->executionContext()->isJSExecutionForbidden())
+    if (executionContext->isJSExecutionForbidden())
         return;
 
+    // A ScriptState used by the event listener needs to be calculated based on
+    // the ExecutionContext that fired the the event listener and the world
+    // that installed the event listener.
     ASSERT(event);
+    v8::HandleScope handleScope(toIsolate(executionContext));
+    v8::Local<v8::Context> v8Context = toV8Context(executionContext, world());
+    if (v8Context.IsEmpty())
+        return;
+    ScriptState* scriptState = ScriptState::from(v8Context);
+    if (scriptState->contextIsEmpty())
+        return;
+    handleEvent(scriptState, event);
+}
 
+void V8AbstractEventListener::handleEvent(ScriptState* scriptState, Event* event)
+{
     // The callback function on XMLHttpRequest can clear the event listener and destroys 'this' object. Keep a local reference to it.
     // See issue 889829.
     RefPtr<V8AbstractEventListener> protect(this);
 
-    ScriptState::Scope scope(scriptState());
+    ScriptState::Scope scope(scriptState);
 
     // Get the V8 wrapper for the event object.
-    v8::Handle<v8::Value> jsEvent = toV8(event, scriptState()->context()->Global(), isolate());
+    v8::Handle<v8::Value> jsEvent = toV8(event, scriptState->context()->Global(), isolate());
     if (jsEvent.IsEmpty())
         return;
-    invokeEventHandler(event, v8::Local<v8::Value>::New(isolate(), jsEvent));
+    invokeEventHandler(scriptState, event, v8::Local<v8::Value>::New(isolate(), jsEvent));
 }
 
 void V8AbstractEventListener::setListenerObject(v8::Handle<v8::Object> listener)
@@ -104,13 +106,8 @@ void V8AbstractEventListener::setListenerObject(v8::Handle<v8::Object> listener)
     m_listener.setWeak(this, &setWeakCallback);
 }
 
-void V8AbstractEventListener::invokeEventHandler(Event* event, v8::Local<v8::Value> jsEvent)
+void V8AbstractEventListener::invokeEventHandler(ScriptState* scriptState, Event* event, v8::Local<v8::Value> jsEvent)
 {
-    // If jsEvent is empty, attempt to set it as a hidden value would crash v8.
-    if (jsEvent.IsEmpty())
-        return;
-
-    ASSERT(!scriptState()->contextIsEmpty());
     v8::Local<v8::Value> returnValue;
     {
         // Catch exceptions thrown in the event handler so they do not propagate to javascript code that caused the event to fire.
@@ -118,29 +115,29 @@ void V8AbstractEventListener::invokeEventHandler(Event* event, v8::Local<v8::Val
         tryCatch.SetVerbose(true);
 
         // Save the old 'event' property so we can restore it later.
-        v8::Local<v8::Value> savedEvent = V8HiddenValue::getHiddenValue(isolate(), scriptState()->context()->Global(), V8HiddenValue::event(isolate()));
+        v8::Local<v8::Value> savedEvent = V8HiddenValue::getHiddenValue(isolate(), scriptState->context()->Global(), V8HiddenValue::event(isolate()));
         tryCatch.Reset();
 
         // Make the event available in the global object, so LocalDOMWindow can expose it.
-        V8HiddenValue::setHiddenValue(isolate(), scriptState()->context()->Global(), V8HiddenValue::event(isolate()), jsEvent);
+        V8HiddenValue::setHiddenValue(isolate(), scriptState->context()->Global(), V8HiddenValue::event(isolate()), jsEvent);
         tryCatch.Reset();
 
-        returnValue = callListenerFunction(jsEvent, event);
+        returnValue = callListenerFunction(scriptState, jsEvent, event);
         if (tryCatch.HasCaught())
             event->target()->uncaughtExceptionInEventHandler();
 
         if (!tryCatch.CanContinue()) { // Result of TerminateExecution().
-            if (scriptState()->executionContext()->isWorkerGlobalScope())
-                toWorkerGlobalScope(scriptState()->executionContext())->script()->forbidExecution();
+            if (scriptState->executionContext()->isWorkerGlobalScope())
+                toWorkerGlobalScope(scriptState->executionContext())->script()->forbidExecution();
             return;
         }
         tryCatch.Reset();
 
         // Restore the old event. This must be done for all exit paths through this method.
         if (savedEvent.IsEmpty())
-            V8HiddenValue::setHiddenValue(isolate(), scriptState()->context()->Global(), V8HiddenValue::event(isolate()), v8::Undefined(isolate()));
+            V8HiddenValue::setHiddenValue(isolate(), scriptState->context()->Global(), V8HiddenValue::event(isolate()), v8::Undefined(isolate()));
         else
-            V8HiddenValue::setHiddenValue(isolate(), scriptState()->context()->Global(), V8HiddenValue::event(isolate()), savedEvent);
+            V8HiddenValue::setHiddenValue(isolate(), scriptState->context()->Global(), V8HiddenValue::event(isolate()), savedEvent);
         tryCatch.Reset();
     }
 
@@ -163,14 +160,14 @@ bool V8AbstractEventListener::shouldPreventDefault(v8::Local<v8::Value> returnVa
     return returnValue->IsBoolean() && !returnValue->BooleanValue();
 }
 
-v8::Local<v8::Object> V8AbstractEventListener::getReceiverObject(Event* event)
+v8::Local<v8::Object> V8AbstractEventListener::getReceiverObject(ScriptState* scriptState, Event* event)
 {
     v8::Local<v8::Object> listener = m_listener.newLocal(isolate());
     if (!m_listener.isEmpty() && !listener->IsFunction())
         return listener;
 
     EventTarget* target = event->currentTarget();
-    v8::Handle<v8::Value> value = toV8(target, scriptState()->context()->Global(), isolate());
+    v8::Handle<v8::Value> value = toV8(target, scriptState->context()->Global(), isolate());
     if (value.IsEmpty())
         return v8::Local<v8::Object>();
     return v8::Local<v8::Object>::New(isolate(), v8::Handle<v8::Object>::Cast(value));

--- a/Source/bindings/core/v8/V8AbstractEventListener.h
+++ b/Source/bindings/core/v8/V8AbstractEventListener.h
@@ -70,19 +70,18 @@ public:
 
     virtual bool operator==(const EventListener& other) OVERRIDE { return this == &other; }
 
-    virtual void handleEvent(ExecutionContext*, Event*) OVERRIDE;
-
-    virtual bool isLazy() const { return false; }
+    virtual void handleEvent(ExecutionContext*, Event*) override final;
+    virtual void handleEvent(ScriptState*, Event*);
 
     // Returns the listener object, either a function or an object.
-    v8::Local<v8::Object> getListenerObject(ExecutionContext* context)
+    v8::Local<v8::Object> getListenerObject(ExecutionContext* executionContext)
     {
         // prepareListenerObject can potentially deref this event listener
         // as it may attempt to compile a function (lazy event listener), get an error
         // and invoke onerror callback which can execute arbitrary JS code.
         // Protect this event listener to keep it alive.
         RefPtr<V8AbstractEventListener> guard(this);
-        prepareListenerObject(context);
+        prepareListenerObject(executionContext);
         return m_listener.newLocal(m_isolate);
     }
 
@@ -110,32 +109,25 @@ public:
 
     virtual bool belongsToTheCurrentWorld() const OVERRIDE FINAL;
     v8::Isolate* isolate() const { return m_isolate; }
-    virtual DOMWrapperWorld& world() const { return scriptState()->world(); }
-    ScriptState* scriptState() const
-    {
-        ASSERT(m_scriptState);
-        return m_scriptState.get();
-    }
-    void setScriptState(ScriptState* scriptState) { m_scriptState = scriptState; }
+    DOMWrapperWorld& world() const { return *m_world; }
 
 protected:
-    V8AbstractEventListener(bool isAttribute, ScriptState*);
-    V8AbstractEventListener(bool isAttribute, v8::Isolate*);
+    V8AbstractEventListener(bool isAttribute, DOMWrapperWorld&, v8::Isolate*);
 
     virtual void prepareListenerObject(ExecutionContext*) { }
 
     void setListenerObject(v8::Handle<v8::Object>);
 
-    void invokeEventHandler(Event*, v8::Local<v8::Value> jsEvent);
+    void invokeEventHandler(ScriptState*, Event*, v8::Local<v8::Value>);
 
     // Get the receiver object to use for event listener call.
-    v8::Local<v8::Object> getReceiverObject(Event*);
+    v8::Local<v8::Object> getReceiverObject(ScriptState*, Event*);
 
 private:
     // Implementation of EventListener function.
     virtual bool virtualisAttribute() const OVERRIDE { return m_isAttribute; }
 
-    virtual v8::Local<v8::Value> callListenerFunction(v8::Handle<v8::Value> jsevent, Event*) = 0;
+    virtual v8::Local<v8::Value> callListenerFunction(ScriptState*, v8::Handle<v8::Value> jsevent, Event*) = 0;
 
     virtual bool shouldPreventDefault(v8::Local<v8::Value> returnValue);
 
@@ -146,10 +138,7 @@ private:
     // Indicates if this is an HTML type listener.
     bool m_isAttribute;
 
-    // For V8LazyEventListener, m_scriptState can be 0 until V8LazyEventListener is actually used.
-    // m_scriptState is set lazily because V8LazyEventListener doesn't know the associated frame
-    // until the listener is actually used.
-    RefPtr<ScriptState> m_scriptState;
+    RefPtr<DOMWrapperWorld> m_world;
     v8::Isolate* m_isolate;
 };
 

--- a/Source/bindings/core/v8/V8ErrorHandler.cpp
+++ b/Source/bindings/core/v8/V8ErrorHandler.cpp
@@ -47,21 +47,20 @@ V8ErrorHandler::V8ErrorHandler(v8::Local<v8::Object> listener, bool isInline, Sc
 {
 }
 
-v8::Local<v8::Value> V8ErrorHandler::callListenerFunction(v8::Handle<v8::Value> jsEvent, Event* event)
+v8::Local<v8::Value> V8ErrorHandler::callListenerFunction(ScriptState* scriptState, v8::Handle<v8::Value> jsEvent, Event* event)
 {
     if (!event->hasInterface(EventNames::ErrorEvent))
-        return V8EventListener::callListenerFunction(jsEvent, event);
+        return V8EventListener::callListenerFunction(scriptState, jsEvent, event);
 
     ErrorEvent* errorEvent = static_cast<ErrorEvent*>(event);
-
     if (errorEvent->world() && errorEvent->world() != &world())
         return v8::Null(isolate());
 
-    v8::Local<v8::Object> listener = getListenerObject(scriptState()->executionContext());
+    v8::Local<v8::Object> listener = getListenerObject(scriptState->executionContext());
     v8::Local<v8::Value> returnValue;
     if (!listener.IsEmpty() && listener->IsFunction()) {
         v8::Local<v8::Function> callFunction = v8::Local<v8::Function>::Cast(listener);
-        v8::Local<v8::Object> thisValue = scriptState()->context()->Global();
+        v8::Local<v8::Object> thisValue = scriptState->context()->Global();
 
         v8::Local<v8::Value> error = V8HiddenValue::getHiddenValue(isolate(), jsEvent->ToObject(), V8HiddenValue::error(isolate()));
         if (error.IsEmpty())
@@ -70,10 +69,10 @@ v8::Local<v8::Value> V8ErrorHandler::callListenerFunction(v8::Handle<v8::Value> 
         v8::Handle<v8::Value> parameters[5] = { v8String(isolate(), errorEvent->message()), v8String(isolate(), errorEvent->filename()), v8::Integer::New(isolate(), errorEvent->lineno()), v8::Integer::New(isolate(), errorEvent->colno()), error };
         v8::TryCatch tryCatch;
         tryCatch.SetVerbose(true);
-        if (scriptState()->executionContext()->isWorkerGlobalScope())
-            returnValue = V8ScriptRunner::callFunction(callFunction, scriptState()->executionContext(), thisValue, WTF_ARRAY_LENGTH(parameters), parameters, isolate());
+        if (scriptState->executionContext()->isWorkerGlobalScope())
+            returnValue = V8ScriptRunner::callFunction(callFunction, scriptState->executionContext(), thisValue, WTF_ARRAY_LENGTH(parameters), parameters, isolate());
         else
-            returnValue = ScriptController::callFunction(scriptState()->executionContext(), callFunction, thisValue, WTF_ARRAY_LENGTH(parameters), parameters, isolate());
+            returnValue = ScriptController::callFunction(scriptState->executionContext(), callFunction, thisValue, WTF_ARRAY_LENGTH(parameters), parameters, isolate());
     }
     return returnValue;
 }

--- a/Source/bindings/core/v8/V8ErrorHandler.h
+++ b/Source/bindings/core/v8/V8ErrorHandler.h
@@ -46,14 +46,12 @@ public:
     {
         return adoptRef(new V8ErrorHandler(listener, isInline, scriptState));
     }
-
     static void storeExceptionOnErrorEventWrapper(ErrorEvent*, v8::Handle<v8::Value>, v8::Handle<v8::Object> creationContext, v8::Isolate*);
 
 private:
     V8ErrorHandler(v8::Local<v8::Object> listener, bool isInline, ScriptState*);
-
-    virtual v8::Local<v8::Value> callListenerFunction(v8::Handle<v8::Value> jsEvent, Event*) OVERRIDE;
-    virtual bool shouldPreventDefault(v8::Local<v8::Value> returnValue) OVERRIDE;
+    virtual v8::Local<v8::Value> callListenerFunction(ScriptState*, v8::Handle<v8::Value>, Event*) override;
+    virtual bool shouldPreventDefault(v8::Local<v8::Value> returnValue) override;
 };
 
 } // namespace blink

--- a/Source/bindings/core/v8/V8EventListener.cpp
+++ b/Source/bindings/core/v8/V8EventListener.cpp
@@ -39,14 +39,14 @@
 namespace blink {
 
 V8EventListener::V8EventListener(v8::Local<v8::Object> listener, bool isAttribute, ScriptState* scriptState)
-    : V8AbstractEventListener(isAttribute, scriptState)
+    : V8AbstractEventListener(isAttribute, scriptState->world(), scriptState->isolate())
 {
     setListenerObject(listener);
 }
 
-v8::Local<v8::Function> V8EventListener::getListenerFunction(ExecutionContext*)
+v8::Local<v8::Function> V8EventListener::getListenerFunction(ScriptState* scriptState)
 {
-    v8::Local<v8::Object> listener = getListenerObject(scriptState()->executionContext());
+    v8::Local<v8::Object> listener = getListenerObject(scriptState->executionContext());
 
     // Has the listener been disposed?
     if (listener.IsEmpty())
@@ -67,17 +67,17 @@ v8::Local<v8::Function> V8EventListener::getListenerFunction(ExecutionContext*)
     return v8::Local<v8::Function>();
 }
 
-v8::Local<v8::Value> V8EventListener::callListenerFunction(v8::Handle<v8::Value> jsEvent, Event* event)
+v8::Local<v8::Value> V8EventListener::callListenerFunction(ScriptState* scriptState, v8::Handle<v8::Value> jsEvent, Event* event)
 {
-    v8::Local<v8::Function> handlerFunction = getListenerFunction(scriptState()->executionContext());
-    v8::Local<v8::Object> receiver = getReceiverObject(event);
+    v8::Local<v8::Function> handlerFunction = getListenerFunction(scriptState);
+    v8::Local<v8::Object> receiver = getReceiverObject(scriptState, event);
     if (handlerFunction.IsEmpty() || receiver.IsEmpty())
         return v8::Local<v8::Value>();
 
-    if (!scriptState()->executionContext()->isDocument())
+    if (!scriptState->executionContext()->isDocument())
         return v8::Local<v8::Value>();
 
-    LocalFrame* frame = toDocument(scriptState()->executionContext())->frame();
+    LocalFrame* frame = toDocument(scriptState->executionContext())->frame();
     if (!frame)
         return v8::Local<v8::Value>();
 

--- a/Source/bindings/core/v8/V8EventListener.h
+++ b/Source/bindings/core/v8/V8EventListener.h
@@ -51,10 +51,8 @@ public:
 
 protected:
     V8EventListener(v8::Local<v8::Object> listener, bool isAttribute, ScriptState*);
-
-    v8::Local<v8::Function> getListenerFunction(ExecutionContext*);
-
-    virtual v8::Local<v8::Value> callListenerFunction(v8::Handle<v8::Value> jsEvent, Event*) OVERRIDE;
+    v8::Local<v8::Function> getListenerFunction(ScriptState*);
+    virtual v8::Local<v8::Value> callListenerFunction(ScriptState*, v8::Handle<v8::Value>, Event*) override;
 };
 
 } // namespace blink

--- a/Source/bindings/core/v8/V8LazyEventListener.cpp
+++ b/Source/bindings/core/v8/V8LazyEventListener.cpp
@@ -53,7 +53,7 @@
 namespace blink {
 
 V8LazyEventListener::V8LazyEventListener(const AtomicString& functionName, const AtomicString& eventParameterName, const String& code, const String sourceURL, const TextPosition& position, Node* node, v8::Isolate* isolate)
-    : V8AbstractEventListener(true, isolate)
+    : V8AbstractEventListener(true, DOMWrapperWorld::mainWorld(), isolate)
     , m_functionName(functionName)
     , m_eventParameterName(eventParameterName)
     , m_code(code)
@@ -74,21 +74,21 @@ v8::Handle<v8::Object> toObjectWrapper(T* domObject, ScriptState* scriptState)
     return v8::Local<v8::Object>::New(scriptState->isolate(), value.As<v8::Object>());
 }
 
-v8::Local<v8::Value> V8LazyEventListener::callListenerFunction(v8::Handle<v8::Value> jsEvent, Event* event)
+v8::Local<v8::Value> V8LazyEventListener::callListenerFunction(ScriptState* scriptState, v8::Handle<v8::Value> jsEvent, Event* event)
 {
-    v8::Local<v8::Object> listenerObject = getListenerObject(scriptState()->executionContext());
+    v8::Local<v8::Object> listenerObject = getListenerObject(scriptState->executionContext());
     if (listenerObject.IsEmpty())
         return v8::Local<v8::Value>();
 
     v8::Local<v8::Function> handlerFunction = listenerObject.As<v8::Function>();
-    v8::Local<v8::Object> receiver = getReceiverObject(event);
+    v8::Local<v8::Object> receiver = getReceiverObject(scriptState, event);
     if (handlerFunction.IsEmpty() || receiver.IsEmpty())
         return v8::Local<v8::Value>();
 
-    if (!scriptState()->executionContext()->isDocument())
+    if (!scriptState->executionContext()->isDocument())
         return v8::Local<v8::Value>();
 
-    LocalFrame* frame = toDocument(scriptState()->executionContext())->frame();
+    LocalFrame* frame = toDocument(scriptState->executionContext())->frame();
     if (!frame)
         return v8::Local<v8::Value>();
 
@@ -104,30 +104,23 @@ static void V8LazyEventListenerToString(const v8::FunctionCallbackInfo<v8::Value
     v8SetReturnValue(info, V8HiddenValue::getHiddenValue(info.GetIsolate(), info.Holder(), V8HiddenValue::toStringString(info.GetIsolate())));
 }
 
-void V8LazyEventListener::handleEvent(ExecutionContext* context, Event* event)
+void V8LazyEventListener::prepareListenerObject(ExecutionContext* executionContext)
 {
-    v8::HandleScope handleScope(toIsolate(context));
-    // V8LazyEventListener doesn't know the associated context when created.
-    // Thus we lazily get the associated context and set a ScriptState on V8AbstractEventListener.
-    v8::Local<v8::Context> v8Context = toV8Context(context, world());
+    if (!executionContext)
+        return;
+
+    // A ScriptState used by the event listener needs to be calculated based on
+    // the ExecutionContext that fired the the event listener and the world
+    // that installed the event listener.
+    v8::HandleScope handleScope(toIsolate(executionContext));
+    v8::Local<v8::Context> v8Context = toV8Context(executionContext, world());
     if (v8Context.IsEmpty())
         return;
-    setScriptState(ScriptState::from(v8Context));
-
-    V8AbstractEventListener::handleEvent(context, event);
-}
-
-void V8LazyEventListener::prepareListenerObject(ExecutionContext* context)
-{
-    v8::HandleScope handleScope(toIsolate(context));
-    // V8LazyEventListener doesn't know the associated context when created.
-    // Thus we lazily get the associated context and set a ScriptState on V8AbstractEventListener.
-    v8::Local<v8::Context> v8Context = toV8Context(context, world());
-    if (v8Context.IsEmpty())
+    ScriptState* scriptState = ScriptState::from(v8Context);
+    if (scriptState->contextIsEmpty())
         return;
-    setScriptState(ScriptState::from(v8Context));
 
-    if (context->isDocument() && !toDocument(context)->allowInlineEventHandlers(m_node, this, m_sourceURL, m_position.m_line)) {
+    if (executionContext->isDocument() && !toDocument(executionContext)->allowInlineEventHandlers(m_node, this, m_sourceURL, m_position.m_line)) {
         clearListenerObject();
         return;
     }
@@ -135,10 +128,10 @@ void V8LazyEventListener::prepareListenerObject(ExecutionContext* context)
     if (hasExistingListenerObject())
         return;
 
-    ASSERT(context->isDocument());
+    ASSERT(executionContext->isDocument());
 
-    ScriptState::Scope scope(scriptState());
-    String listenerSource =  InspectorInstrumentation::preprocessEventListener(toDocument(context)->frame(), m_code, m_sourceURL, m_functionName);
+    ScriptState::Scope scope(scriptState);
+    String listenerSource =  InspectorInstrumentation::preprocessEventListener(toDocument(executionContext)->frame(), m_code, m_sourceURL, m_functionName);
 
     // FIXME: Remove the following 'with' hack.
     //
@@ -180,9 +173,9 @@ void V8LazyEventListener::prepareListenerObject(ExecutionContext* context)
     if (m_node && m_node->isHTMLElement())
         formElement = toHTMLElement(m_node)->formOwner();
 
-    v8::Handle<v8::Object> nodeWrapper = toObjectWrapper<Node>(m_node, scriptState());
-    v8::Handle<v8::Object> formWrapper = toObjectWrapper<HTMLFormElement>(formElement, scriptState());
-    v8::Handle<v8::Object> documentWrapper = toObjectWrapper<Document>(m_node ? m_node->ownerDocument() : 0, scriptState());
+    v8::Handle<v8::Object> nodeWrapper = toObjectWrapper<Node>(m_node, scriptState);
+    v8::Handle<v8::Object> formWrapper = toObjectWrapper<HTMLFormElement>(formElement, scriptState);
+    v8::Handle<v8::Object> documentWrapper = toObjectWrapper<Document>(m_node ? m_node->ownerDocument() : 0, scriptState);
 
     v8::Local<v8::Object> thisObject = v8::Object::New(isolate());
     if (thisObject.IsEmpty())

--- a/Source/bindings/core/v8/V8LazyEventListener.h
+++ b/Source/bindings/core/v8/V8LazyEventListener.h
@@ -34,30 +34,21 @@
 #include "bindings/core/v8/V8AbstractEventListener.h"
 #include "wtf/PassRefPtr.h"
 #include "wtf/text/TextPosition.h"
-#include "wtf/text/WTFString.h"
 #include <v8.h>
 
 namespace blink {
 
 class Event;
-class LocalFrame;
-class HTMLFormElement;
 class Node;
 
 // V8LazyEventListener is a wrapper for a JavaScript code string that is compiled and evaluated when an event is fired.
 // A V8LazyEventListener is either a HTML or SVG event handler.
-class V8LazyEventListener FINAL : public V8AbstractEventListener {
+class V8LazyEventListener final : public V8AbstractEventListener {
 public:
     static PassRefPtr<V8LazyEventListener> create(const AtomicString& functionName, const AtomicString& eventParameterName, const String& code, const String& sourceURL, const TextPosition& position, Node* node, v8::Isolate* isolate)
     {
         return adoptRef(new V8LazyEventListener(functionName, eventParameterName, code, sourceURL, position, node, isolate));
     }
-
-    virtual bool isLazy() const OVERRIDE { return true; }
-    // V8LazyEventListener is always for the main world.
-    virtual DOMWrapperWorld& world() const OVERRIDE { return DOMWrapperWorld::mainWorld(); }
-
-    virtual void handleEvent(ExecutionContext*, Event*) OVERRIDE;
 
 protected:
     virtual void prepareListenerObject(ExecutionContext*) OVERRIDE;
@@ -65,13 +56,13 @@ protected:
 private:
     V8LazyEventListener(const AtomicString& functionName, const AtomicString& eventParameterName, const String& code, const String sourceURL, const TextPosition&, Node*, v8::Isolate*);
 
-    virtual v8::Local<v8::Value> callListenerFunction(v8::Handle<v8::Value> jsEvent, Event*) OVERRIDE;
+    virtual v8::Local<v8::Value> callListenerFunction(ScriptState*, v8::Handle<v8::Value>, Event*) override;
 
     // Needs to return true for all event handlers implemented in JavaScript so that
     // the SVG code does not add the event handler in both
     // SVGUseElement::buildShadowTree and again in
     // SVGUseElement::transferEventListenersToShadowTree
-    virtual bool wasCreatedFromMarkup() const OVERRIDE { return true; }
+    virtual bool wasCreatedFromMarkup() const override { return true; }
 
     AtomicString m_functionName;
     AtomicString m_eventParameterName;

--- a/Source/bindings/core/v8/V8WorkerGlobalScopeEventListener.cpp
+++ b/Source/bindings/core/v8/V8WorkerGlobalScopeEventListener.cpp
@@ -50,47 +50,44 @@ V8WorkerGlobalScopeEventListener::V8WorkerGlobalScopeEventListener(v8::Local<v8:
 {
 }
 
-void V8WorkerGlobalScopeEventListener::handleEvent(ExecutionContext*, Event* event)
+void V8WorkerGlobalScopeEventListener::handleEvent(ScriptState* scriptState, Event* event)
 {
     // The callback function on XMLHttpRequest can clear the event listener and destroys 'this' object. Keep a local reference to it.
     // See issue 889829.
     RefPtr<V8AbstractEventListener> protect(this);
 
-    WorkerScriptController* script = toWorkerGlobalScope(scriptState()->executionContext())->script();
+    WorkerScriptController* script = toWorkerGlobalScope(scriptState->executionContext())->script();
     if (!script)
         return;
 
-    if (scriptState()->contextIsEmpty())
-        return;
-    ScriptState::Scope scope(scriptState());
+    ScriptState::Scope scope(scriptState);
 
     // Get the V8 wrapper for the event object.
-    v8::Handle<v8::Value> jsEvent = toV8(event, scriptState()->context()->Global(), isolate());
+    v8::Handle<v8::Value> jsEvent = toV8(event, scriptState->context()->Global(), isolate());
 
-    invokeEventHandler(event, v8::Local<v8::Value>::New(isolate(), jsEvent));
+    invokeEventHandler(scriptState, event, v8::Local<v8::Value>::New(isolate(), jsEvent));
 }
 
-v8::Local<v8::Value> V8WorkerGlobalScopeEventListener::callListenerFunction(v8::Handle<v8::Value> jsEvent, Event* event)
+v8::Local<v8::Value> V8WorkerGlobalScopeEventListener::callListenerFunction(ScriptState* scriptState, v8::Handle<v8::Value> jsEvent, Event* event)
 {
-    v8::Local<v8::Function> handlerFunction = getListenerFunction(scriptState()->executionContext());
-    v8::Local<v8::Object> receiver = getReceiverObject(event);
+    v8::Local<v8::Function> handlerFunction = getListenerFunction(scriptState);
+    v8::Local<v8::Object> receiver = getReceiverObject(scriptState, event);
     if (handlerFunction.IsEmpty() || receiver.IsEmpty())
         return v8::Local<v8::Value>();
 
-    TRACE_EVENT1(TRACE_DISABLED_BY_DEFAULT("devtools.timeline"), "FunctionCall", "data", devToolsTraceEventData(scriptState()->executionContext(), handlerFunction, isolate()));
-    TRACE_EVENT_INSTANT1(TRACE_DISABLED_BY_DEFAULT("devtools.timeline.stack"), "CallStack", "stack", InspectorCallStackEvent::currentCallStack());
+    TRACE_EVENT1(TRACE_DISABLED_BY_DEFAULT("devtools.timeline"), "FunctionCall", "data", devToolsTraceEventData(scriptState->executionContext(), handlerFunction, isolate()));
     // FIXME(361045): remove InspectorInstrumentation calls once DevTools Timeline migrates to tracing.
     InspectorInstrumentationCookie cookie;
-    if (InspectorInstrumentation::timelineAgentEnabled(scriptState()->executionContext())) {
+    if (InspectorInstrumentation::hasFrontends()) {
         int scriptId = 0;
         String resourceName;
         int lineNumber = 1;
         GetDevToolsFunctionInfo(handlerFunction, isolate(), scriptId, resourceName, lineNumber);
-        cookie = InspectorInstrumentation::willCallFunction(scriptState()->executionContext(), scriptId, resourceName, lineNumber);
+        cookie = InspectorInstrumentation::willCallFunction(scriptState->executionContext(), scriptId, resourceName, lineNumber);
     }
 
     v8::Handle<v8::Value> parameters[1] = { jsEvent };
-    v8::Local<v8::Value> result = V8ScriptRunner::callFunction(handlerFunction, scriptState()->executionContext(), receiver, WTF_ARRAY_LENGTH(parameters), parameters, isolate());
+    v8::Local<v8::Value> result = V8ScriptRunner::callFunction(handlerFunction, scriptState->executionContext(), receiver, WTF_ARRAY_LENGTH(parameters), parameters, isolate());
 
     InspectorInstrumentation::didCallFunction(cookie);
     TRACE_EVENT_INSTANT1(TRACE_DISABLED_BY_DEFAULT("devtools.timeline"), "UpdateCounters", "data", InspectorUpdateCountersEvent::data());
@@ -98,15 +95,17 @@ v8::Local<v8::Value> V8WorkerGlobalScopeEventListener::callListenerFunction(v8::
     return result;
 }
 
-v8::Local<v8::Object> V8WorkerGlobalScopeEventListener::getReceiverObject(Event* event)
+// FIXME: Remove getReceiverObject().
+// This is almost identical to V8AbstractEventListener::getReceiverObject().
+v8::Local<v8::Object> V8WorkerGlobalScopeEventListener::getReceiverObject(ScriptState* scriptState, Event* event)
 {
-    v8::Local<v8::Object> listener = getListenerObject(scriptState()->executionContext());
+    v8::Local<v8::Object> listener = getListenerObject(scriptState->executionContext());
 
     if (!listener.IsEmpty() && !listener->IsFunction())
         return listener;
 
     EventTarget* target = event->currentTarget();
-    v8::Handle<v8::Value> value = toV8(target, scriptState()->context()->Global(), isolate());
+    v8::Handle<v8::Value> value = toV8(target, scriptState->context()->Global(), isolate());
     if (value.IsEmpty())
         return v8::Local<v8::Object>();
     return v8::Local<v8::Object>::New(isolate(), v8::Handle<v8::Object>::Cast(value));

--- a/Source/bindings/core/v8/V8WorkerGlobalScopeEventListener.h
+++ b/Source/bindings/core/v8/V8WorkerGlobalScopeEventListener.h
@@ -39,21 +39,21 @@ namespace blink {
 
 class Event;
 
-class V8WorkerGlobalScopeEventListener FINAL : public V8EventListener {
+class V8WorkerGlobalScopeEventListener final : public V8EventListener {
 public:
     static PassRefPtr<V8WorkerGlobalScopeEventListener> create(v8::Local<v8::Object> listener, bool isInline, ScriptState* scriptState)
     {
         return adoptRef(new V8WorkerGlobalScopeEventListener(listener, isInline, scriptState));
     }
 
-    virtual void handleEvent(ExecutionContext*, Event*) OVERRIDE;
+    virtual void handleEvent(ScriptState*, Event*) override;
 
 protected:
     V8WorkerGlobalScopeEventListener(v8::Local<v8::Object> listener, bool isInline, ScriptState*);
 
 private:
-    virtual v8::Local<v8::Value> callListenerFunction(v8::Handle<v8::Value> jsEvent, Event*) OVERRIDE;
-    v8::Local<v8::Object> getReceiverObject(Event*);
+    virtual v8::Local<v8::Value> callListenerFunction(ScriptState*, v8::Handle<v8::Value>, Event*) override;
+    v8::Local<v8::Object> getReceiverObject(ScriptState*, Event*);
 };
 
 } // namespace blink

--- a/Source/core/frame/LocalDOMWindow.cpp
+++ b/Source/core/frame/LocalDOMWindow.cpp
@@ -34,6 +34,7 @@
 #include "bindings/core/v8/ScriptCallStackFactory.h"
 #include "bindings/core/v8/ScriptController.h"
 #include "bindings/core/v8/SerializedScriptValue.h"
+#include "bindings/core/v8/V8AbstractEventListener.h"
 #include "bindings/core/v8/V8DOMActivityLogger.h"
 #include "core/css/CSSComputedStyleDeclaration.h"
 #include "core/css/CSSRuleList.h"
@@ -1511,8 +1512,9 @@ static void didAddStorageEventListener(LocalDOMWindow* window)
     window->sessionStorage(IGNORE_EXCEPTION);
 }
 
-bool LocalDOMWindow::addEventListener(const AtomicString& eventType, PassRefPtr<EventListener> listener, bool useCapture)
+bool LocalDOMWindow::addEventListener(const AtomicString& eventType, PassRefPtr<EventListener> prpListener, bool useCapture)
 {
+    RefPtr<EventListener> listener = prpListener;
     if (!EventTarget::addEventListener(eventType, listener, useCapture))
         return false;
 

--- a/Source/web/tests/CustomEventTest.cpp
+++ b/Source/web/tests/CustomEventTest.cpp
@@ -60,12 +60,12 @@ public:
         return true;
     }
 
-    virtual void handleEvent(ExecutionContext* context, Event* event)
+    virtual void handleEvent(ScriptState* scriptState, Event* event)
     {
         EXPECT_EQ(event->type(), "blah");
 
-        ScriptState::Scope scope(scriptState());
-        v8::Handle<v8::Value> jsEvent = toV8(event, scriptState()->context()->Global(), isolate());
+        ScriptState::Scope scope(scriptState);
+        v8::Handle<v8::Value> jsEvent = toV8(event, scriptState->context()->Global(), isolate());
 
         EXPECT_EQ(jsEvent->ToObject()->Get(v8::String::NewFromUtf8(scriptState()->isolate(), "detail")), v8::Boolean::New(scriptState()->isolate(), true));
     }
@@ -77,11 +77,11 @@ public:
 
 private:
     TestListener(ScriptState* scriptState)
-        : V8AbstractEventListener(false, scriptState)
+        : V8AbstractEventListener(false, scriptState->world(), scriptState->isolate())
     {
     }
 
-    virtual v8::Local<v8::Value> callListenerFunction(v8::Handle<v8::Value> jsevent, Event*)
+    virtual v8::Local<v8::Value> callListenerFunction(ScriptState*, v8::Handle<v8::Value>, Event*)
     {
         ASSERT_NOT_REACHED();
         return v8::Local<v8::Value>();


### PR DESCRIPTION
This CL is a revert of r175241 (which was landed 6 months ago), essentially.

Currently an event listener is fired in a ScriptState that installed the event listener, but this is wrong. An event listener must be fired in a ScriptState that is calculated based on the ExecutionContext that fired the event listener and the world that installed the event listener. This is what we had been doing before r175241, and this CL restores the behavior. See an added test case for more details. The new behavior aligns with the spec and Firefox.

One tricky part is how to handle a beforeunload event. A return value of a beforeunload event needs to be fired in a ScriptState that installed the beforeunload event listener. To achieve the behavior, this CL records the ScriptState onto V8AbstractEventListener::m_scriptStateForBeforeUnload.

BUG=422227
TEST=event-should-be-dispatched-for-correct-frame.html,before-unload-return-bad-value.html

Review URL: https://codereview.chromium.org/823263002

git-svn-id: svn://svn.chromium.org/blink/trunk@187861 bbb929c8-8fbe-4397-9dbb-9b2b20218538
