### PR TITLE
Fix of uncaughtException should not catch browser exception

### DIFF
--- a/Source/bindings/core/v8/V8Initializer.cpp
+++ b/Source/bindings/core/v8/V8Initializer.cpp
@@ -153,18 +153,24 @@ static void messageHandlerInMainThread(v8::Handle<v8::Message> message, v8::Hand
     }
     // If called during context initialization, there will be no entered window.
     LocalDOMWindow* enteredWindow = enteredDOMWindow(isolate);
-    if (enteredWindow)  {
-        Frame* frame = enteredWindow->document()->frame();
-        if (frame && frame->isNodeJS()) {
+    // pass messages to node only if the object is created from node context
+    if (data->IsObject() && data->ToObject()->CreationContext() == node::g_context) {
+        if (enteredWindow)  {
+            Frame* frame = enteredWindow->document()->frame();
+            if (frame && frame->isNodeJS()) {
+                v8::Local<v8::Context> node_context =
+                    v8::Local<v8::Context>::New(isolate, node::g_context);
+                node_context->Enter();
+                node::OnMessage(message, data);
+                node_context->Exit();
+            }
+        } else {
             v8::Local<v8::Context> node_context =
                 v8::Local<v8::Context>::New(isolate, node::g_context);
             node_context->Enter();
             node::OnMessage(message, data);
             node_context->Exit();
         }
-    } else {
-        node::OnMessage(message, data);
-        return;
     }
 
     if (!enteredWindow || !enteredWindow->isCurrentlyDisplayedInFrame())


### PR DESCRIPTION
In node.js, error caught by `uncaughtException` means application crash. But errors generated by libraries written for browser doesn't. Usually user can ignore those browser generated errors.

This patch only forward exceptions created in node context to `uncaughtException` (fix nwjs/nw.js#3061).

**Limitation: non-object exceptions will not be passed to `uncaughtException` since I can't tell if a number or a boolean is generated from node context**
