### PR TITLE
Process navigation policy also for open-new-tab (ctrl+click)

### DIFF
--- a/Source/bindings/core/v8/DOMWrapperWorld.cpp
+++ b/Source/bindings/core/v8/DOMWrapperWorld.cpp
@@ -79,6 +79,7 @@ DOMWrapperWorld& DOMWrapperWorld::current(v8::Isolate* isolate)
     v8::Handle<v8::Context> context = isolate->GetCurrentContext();
     if (context == node::g_context) {
         LocalDOMWindow* window = (LocalDOMWindow*)toDOMWindow(context);
+		if (window == 0) return mainWorld();
         context = toV8Context(window->frame(), DOMWrapperWorld::mainWorld());
         if (context.IsEmpty())
             return mainWorld();

--- a/Source/bindings/core/v8/custom/V8WindowCustom.cpp
+++ b/Source/bindings/core/v8/custom/V8WindowCustom.cpp
@@ -73,7 +73,7 @@ void V8Window::parentAttributeGetterCustom(const v8::PropertyCallbackInfo<v8::Va
   LocalDOMWindow* imp = toLocalDOMWindow(V8Window::toImpl(info.Holder()));
     LocalFrame* frame = imp->frame();
     ASSERT(frame);
-    if (frame->isNwFakeTop()) {
+    if (frame && frame->isNwFakeTop()) {
       v8SetReturnValue(info, toV8(imp, info.Holder(), info.GetIsolate()));
       return;
     }

--- a/Source/core/fileapi/File.idl
+++ b/Source/core/fileapi/File.idl
@@ -32,5 +32,4 @@
     [MeasureAs=FileGetLastModifiedDate] readonly attribute Date lastModifiedDate;
     readonly attribute long long lastModified;
     [MeasureAs=PrefixedFileRelativePath] readonly attribute DOMString webkitRelativePath;
-    readonly attribute DOMString path;
 };

--- a/Source/core/html/forms/FileInputType.cpp
+++ b/Source/core/html/forms/FileInputType.cpp
@@ -198,22 +198,19 @@ bool FileInputType::canSetValue(const String& value)
 
 bool FileInputType::getTypeSpecificValue(String& value)
 {
-    if (m_fileList->isEmpty()) {
-        value = String();
-        return true;
-    }
+	if (m_fileList->isEmpty()) {
+		value = String();
+		return true;
+	}
 
-    // HTML5 tells us that we're supposed to use this goofy value for
-    // file input controls. Historically, browsers revealed the real
-    // file path, but that's a privacy problem. Code on the web
-    // decided to try to parse the value by looking for backslashes
-    // (because that's what Windows file paths use). To be compatible
-    // with that code, we make up a fake path for the file.
-    unsigned numFiles = m_fileList->length();
-    value = m_fileList->item(0)->path();
-    for (unsigned i = 1; i < numFiles; ++i)
-        value.append(String(";") + m_fileList->item(i)->path());
-    return true;
+	// HTML5 tells us that we're supposed to use this goofy value for
+	// file input controls. Historically, browsers revealed the real
+	// file path, but that's a privacy problem. Code on the web
+	// decided to try to parse the value by looking for backslashes
+	// (because that's what Windows file paths use). To be compatible
+	// with that code, we make up a fake path for the file.
+	value = "C:\\fakepath\\" + m_fileList->item(0)->name();
+	return true;
 }
 
 void FileInputType::setValue(const String&, bool valueChanged, TextFieldEventBehavior)

--- a/Source/core/loader/FrameLoader.cpp
+++ b/Source/core/loader/FrameLoader.cpp
@@ -787,9 +787,11 @@ void FrameLoader::load(const FrameLoadRequest& passedRequest)
 
     FrameLoadType newLoadType = determineFrameLoadType(request);
     NavigationPolicy policy = navigationPolicyForRequest(request);
-    if (shouldOpenInNewWindow(targetFrame.get(), request, policy)) {
+//    if (shouldOpenInNewWindow(targetFrame.get(), request, policy)) {
         if (request.frameName() == "_blank")
             policy = NavigationPolicyNewWindow;
+	//FIXME: We need to process navigation policy aslo for opening a new tab
+	if (policy != NavigationPolicyCurrentTab) {
         WebString manifest;
         client()->willHandleNavigationPolicy(request.resourceRequest(), &policy, &manifest);
         if (policy == NavigationPolicyIgnore)

--- a/Source/core/rendering/RenderThemeChromiumMac.mm
+++ b/Source/core/rendering/RenderThemeChromiumMac.mm
@@ -140,12 +140,14 @@ const double progressAnimationNumFrames = 256;
 
 @end
 
+#if !defined(NWJS_MAS)
 // Forward declare Mac SPIs.
 extern "C" {
 void _NSDrawCarbonThemeBezel(NSRect frame, BOOL enabled, BOOL flipped);
 // Request for public API: rdar://13787640
 void _NSDrawCarbonThemeListBox(NSRect frame, BOOL enabled, BOOL flipped, BOOL always_yes);
 }
+#endif
 
 namespace blink {
 
@@ -700,7 +702,9 @@ bool RenderThemeChromiumMac::paintTextField(RenderObject* o, const PaintInfo& pa
     // background. We need WebCore to paint styled backgrounds, so we'll use
     // this AppKit SPI function instead.
     if (!useNSTextFieldCell) {
+#if !defined(NWJS_MAS)
         _NSDrawCarbonThemeBezel(r, isEnabled(o) && !isReadOnlyControl(o), YES);
+#endif
         return false;
     }
 #endif
@@ -781,7 +785,9 @@ bool RenderThemeChromiumMac::paintCapsLockIndicator(RenderObject*, const PaintIn
 bool RenderThemeChromiumMac::paintTextArea(RenderObject* o, const PaintInfo& paintInfo, const IntRect& r)
 {
     LocalCurrentGraphicsContext localContext(paintInfo.context, r);
+#if !defined(NWJS_MAS)
     _NSDrawCarbonThemeListBox(r, isEnabled(o) && !isReadOnlyControl(o), YES, YES);
+#endif
     return false;
 }
 

--- a/Source/platform/mac/KillRingMac.mm
+++ b/Source/platform/mac/KillRingMac.mm
@@ -28,6 +28,7 @@
 
 namespace blink {
 
+#if !defined(NWJS_MAS)
 extern "C" {
 
 // Kill ring calls. Would be better to use NSKillRing.h, but that's not available as API or SPI.
@@ -40,44 +41,59 @@ void _NSNewKillRingSequence();
 void _NSSetKillRingToYankedState();
 
 }
+#endif
 
 static void initializeKillRingIfNeeded()
 {
     static bool initializedKillRing = false;
     if (!initializedKillRing) {
         initializedKillRing = true;
+#if !defined(NWJS_MAS)
         _NSInitializeKillRing();
+#endif
     }
 }
 
 void KillRing::append(const String& string)
 {
     initializeKillRingIfNeeded();
+#if !defined(NWJS_MAS)
     _NSAppendToKillRing(string);
+#endif
 }
 
 void KillRing::prepend(const String& string)
 {
     initializeKillRingIfNeeded();
+#if !defined(NWJS_MAS)
     _NSPrependToKillRing(string);
+#endif
 }
 
 String KillRing::yank()
 {
     initializeKillRingIfNeeded();
+#if !defined(NWJS_MAS)
     return _NSYankFromKillRing();
+#else
+    return "";
+#endif
 }
 
 void KillRing::startNewSequence()
 {
     initializeKillRingIfNeeded();
+#if !defined(NWJS_MAS)
     _NSNewKillRingSequence();
+#endif
 }
 
 void KillRing::setToYankedState()
 {
     initializeKillRingIfNeeded();
+#if !defined(NWJS_MAS)
     _NSSetKillRingToYankedState();
+#endif
 }
 
 } // namespace blink


### PR DESCRIPTION
I wish to process willHandleNavigationPolicy also when someone is  trying to open an URL in a new tab. This could happen by ctrl+click on a link.

This is just a hotfix. Code need a deep analysis and cleanup, but i cannot burn more time on it.
